### PR TITLE
fix: renumber Unicode rule from E020 to E012 for sequential numbering

### DIFF
--- a/internal/ruleset.go
+++ b/internal/ruleset.go
@@ -78,8 +78,8 @@ var RuleSet = map[string]Rule{
 		Description: "Version type is not set to 'custom' (should be avoided per schema docs)",
 		CheckFunc:   rules.CheckCustomVersionType,
 	},
-	"E020": {
-		Code:        "E020",
+	"E012": {
+		Code:        "E012",
 		Name:        "check-unicode-escape-sequences",
 		Description: "Descriptions do not contain Unicode escape sequences; UTF-8 characters should be used instead",
 		CheckFunc:   rules.CheckUnicodeEscapeSequences,


### PR DESCRIPTION
This PR fixes the rule numbering to be sequential without gaps.

## Changes
- Changed Unicode escape sequence rule from E020 to E012
- Eliminates the gap between E011 and the next rule
- Allows dependent PRs (#20 and #21) to use sequential numbering (E013-E014 for PURL, E015-E020 for CNA)

## Why This Matters
PR #19 (Unicode validation) was merged with E020, creating a gap. This should have been E012 to keep numbering sequential. With this fix:
- E001-E011: Original rules
- E012: Unicode
- E013-E014: PURL (PR #20)
- E015-E020: CNA Rules v4.0 (PR #21)

This fix is needed before merging PRs #20 and #21.