### PR TITLE
fix: use cveMetadata.cveId in CNA basic rule

### DIFF
--- a/internal/rules/cna_rules.go
+++ b/internal/rules/cna_rules.go
@@ -20,16 +20,16 @@ func CheckCNARulesV4_0Basic(json *string) []ValidationError {
 	var errors []ValidationError
 
 	// Check CVE ID format
-	cveId := gjson.Get(*json, `cveMetadata.id`).String()
+	cveId := gjson.Get(*json, `cveMetadata.cveId`).String()
 	if cveId == "" {
 		errors = append(errors, ValidationError{
 			Text:     "CVE ID must be present",
-			JsonPath: "cveMetadata.id",
+			JsonPath: "cveMetadata.cveId",
 		})
 	} else if !strings.HasPrefix(cveId, "CVE-") {
 		errors = append(errors, ValidationError{
 			Text:     fmt.Sprintf("Invalid CVE ID format: %s (must start with CVE-)", cveId),
-			JsonPath: "cveMetadata.id",
+			JsonPath: "cveMetadata.cveId",
 		})
 	}
 

--- a/internal/rules/cna_rules_test.go
+++ b/internal/rules/cna_rules_test.go
@@ -15,7 +15,7 @@ func TestCheckCNARulesV4_0Basic(t *testing.T) {
 			name: "Valid CVE ID and state",
 			json: `{
 				"cveMetadata": {
-					"id": "CVE-2023-12345",
+					"cveId": "CVE-2023-12345",
 					"state": "PUBLISHED"
 				},
 				"containers": {"cna": {}}
@@ -27,7 +27,7 @@ func TestCheckCNARulesV4_0Basic(t *testing.T) {
 			name: "Invalid CVE ID format",
 			json: `{
 				"cveMetadata": {
-					"id": "2023-12345",
+					"cveId": "2023-12345",
 					"state": "PUBLISHED"
 				},
 				"containers": {"cna": {}}
@@ -39,7 +39,7 @@ func TestCheckCNARulesV4_0Basic(t *testing.T) {
 			name: "Invalid state",
 			json: `{
 				"cveMetadata": {
-					"id": "CVE-2023-12345",
+					"cveId": "CVE-2023-12345",
 					"state": "DRAFT"
 				},
 				"containers": {"cna": {}}


### PR DESCRIPTION
## Summary
This PR fixes a bug introduced in PR #21 where the CNA basic validation rule incorrectly expected the CVE ID to be located at `cveMetadata.id`. 

Per the [CVE v5 JSON schema](https://cveproject.github.io/cve-schema/schema/docs/#oneOf_i0_cveMetadata_cveId), the correct and canonical field name is `cveMetadata.cveId`. Using the incorrect field `id` caused the linter to falsely fail valid CVE records with a "CVE ID must be present" error.

## Changes
- **Fix Field Path**: Updated `CheckCNARulesV4_0Basic` in `internal/rules/cna_rules.go` to extract and validate `cveMetadata.cveId`.
- **Align Tests**: Updated the corresponding test fixtures in `internal/rules/cna_rules_test.go` to reflect the correct schema structure, replacing legacy `id` fields with `cveId`.
- **Consistency**: This brings the CNA rules inline with the rest of the cvelint codebase (such as `references.go`), which already correctly utilizes `cveId`.

## Validation
- `go test ./internal/rules -run TestCheckCNARulesV4_0Basic` passes with the updated schema-compliant fixtures.
- `go test ./...` passes with zero regressions.
